### PR TITLE
Issue #2949033: allow subclasses of ParagraphsWidget

### DIFF
--- a/paragraphs_features.module
+++ b/paragraphs_features.module
@@ -9,13 +9,17 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\WidgetInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget;
 
 /**
- * Implements hook_field_widget_multivalue_WIDGET_TYPE_form_alter().
+ * Implements hook_field_widget_multivalue_form_alter().
  */
-function paragraphs_features_field_widget_multivalue_paragraphs_form_alter(array &$elements, FormStateInterface $form_state, array $context) {
+function paragraphs_features_field_widget_multivalue_form_alter(array &$elements, FormStateInterface $form_state, array $context) {
   /** @var \Drupal\paragraphs\Plugin\Field\FieldWidget\ParagraphsWidget $widget */
   $widget = $context['widget'];
+  if (!($widget instanceof ParagraphsWidget)) {
+    return;
+  }
   if ($widget->getSetting('add_mode') === 'modal' && $widget->getThirdPartySetting('paragraphs_features', 'add_in_between')) {
     // Logic for getting field wrapper ID is taken from Paragraphs module.
     $fieldWrapperId = Html::getId(implode('-', array_merge($context['form']['#parents'], [$elements['#field_name']])) . '-add-more-wrapper');
@@ -31,7 +35,7 @@ function paragraphs_features_field_widget_multivalue_paragraphs_form_alter(array
 function paragraphs_features_field_widget_third_party_settings_form(WidgetInterface $plugin, FieldDefinitionInterface $field_definition, $form_mode, $form, FormStateInterface $form_state) {
   $element = [];
 
-  if ($plugin->getPluginId() === 'paragraphs') {
+  if ($plugin instanceof ParagraphsWidget) {
     // Define rule for enabling/disabling "add in between" option.
     $display_add_in_between_option_rule = [
       ':input[name="fields[' . $field_definition->getName() . '][settings_edit_form][settings][add_mode]"]' => [


### PR DESCRIPTION
See https://www.drupal.org/project/paragraphs_features/issues/2949033.
If someone uses different paragraphs widgets it would be great if the module still added its magic.