### PR TITLE
Issue #2978825: Thunder admin theme table check sorting is very slow

### DIFF
--- a/js/paragraphs-features.add-in-between.js
+++ b/js/paragraphs-features.add-in-between.js
@@ -210,12 +210,10 @@
       var allDrags = $table.find('> tbody > tr.draggable');
       var allAdds = $table.find('> tbody > tr.paragraphs-features__add-in-between__row');
 
+      // We have to re-stripe add in between rows.
       allDrags.each(function (index, dragElem) {
-        var $paragraphRow = $(dragElem);
-        if ($paragraphRow.prev('tr').hasClass('draggable')) {
-          Drupal.detachBehaviors(allAdds[index], drupalSettings, 'move');
+        if (allAdds[index]) {
           $(dragElem).before(allAdds[index]);
-          Drupal.attachBehaviors(allAdds[index], drupalSettings);
         }
       });
     };


### PR DESCRIPTION
Following changes are done:
- removed behaviour re-attaching for add in between buttons
- fixed re-striping of buttons (drag -> scroll should work better now)